### PR TITLE
Proteome CDE group of variables added

### DIFF
--- a/variables.json
+++ b/variables.json
@@ -349,6 +349,52 @@
       ]
     },
     {
+      "code": "proteome",
+      "groups": [
+        {
+          "code": "csf_proteome",
+          "description": "Protein content of the cerebrospinal fluid",
+          "label": "Cerebrospinal fluid",
+          "variables": [
+            {
+              "code": "ab1_42",
+              "description": "Aβ is the main component of amyloid plaques (extracellular deposits found in the brains of patients with Alzheimer's disease). Similar plaques appear in some variants of Lewy body dementia and in inclusion body myositis (a muscle disease), while Aβ can also form the aggregates that coat cerebral blood vessels in cerebral amyloid angiopathy. The plaques are composed of a tangle of regularly ordered fibrillar aggregates called amyloid fibers, a protein fold shared by other peptides such as the prions associated with protein misfolding diseases.",
+              "label": "Level of amyloid beta 1-42 peptides in cerebrospinal fluid",
+              "methodology": "mip-cde",
+              "type": "real",
+              "units": ""
+            },
+            {
+              "code": "ab1_40",
+              "description": "Aβ is the main component of amyloid plaques (extracellular deposits found in the brains of patients with Alzheimer's disease). Similar plaques appear in some variants of Lewy body dementia and in inclusion body myositis (a muscle disease), while Aβ can also form the aggregates that coat cerebral blood vessels in cerebral amyloid angiopathy. The plaques are composed of a tangle of regularly ordered fibrillar aggregates called amyloid fibers, a protein fold shared by other peptides such as the prions associated with protein misfolding diseases.",
+              "label": "Level od amyloid beta 1-40 peptides ion cerebrospinal fluid",
+              "methodology": "mip-cde",
+              "type": "real",
+              "units": ""
+            },
+            {
+              "code": "t_tau",
+              "description": "Tau proteins (or τ proteins) are proteins that stabilize microtubules. They are abundant in neurons of the central nervous system and are less common elsewhere, but are also expressed at very low levels in CNS astrocytes and oligodendrocytes. Pathologies and dementias of the nervous system such as Alzheimer's disease and Parkinson's disease are associated with tau proteins that have become defective and no longer stabilize microtubules properly.",
+              "label": "Total level of tau proteins in cerebrospinal fluid",
+              "methodology": "mip-cde",
+              "type": "real",
+              "units": ""
+            },
+            {
+              "code": "p_tau",
+              "description": "Hyperphosphorylation of the tau protein (tau inclusions, pTau) can result in the self-assembly of tangles of paired helical filaments and straight filaments, which are involved in the pathogenesis of Alzheimer's disease, frontotemporal dementia, and other tauopathies.",
+              "label": "Level of phosphorylated tau proteins in cerebrospinal fluid ",
+              "methodology": "mip-cde",
+              "type": "real",
+              "units": ""
+            }
+          ]
+        }
+      ],
+      "description": "Protein biology as detected using routine lab chemistries in blood and cerebrospinal fluid specimens as well as in biopsy, measurement of protein-protein interactions, level of antibodies, auto-antibodies, etc.",
+      "label": "Entire set of proteins expressed by the patient's organism at the time of the medical workup"
+    },  
+    {
       "code": "brain_anatomy",
       "groups": [
         {


### PR DESCRIPTION
Here is a proposed addition of 4 new CDE variables and a new CDE group (proteome). It's a minimum set necessary for the execution of federated system validation test cases.